### PR TITLE
Catch geoIP initialization error.

### DIFF
--- a/tracking_analyzer/manager.py
+++ b/tracking_analyzer/manager.py
@@ -55,8 +55,8 @@ class TrackerManager(models.Manager):
             logger.debug(
                 'Could not determine IP address for request %s', request)
         else:
-            geo = GeoIP2()
             try:
+                geo = GeoIP2()
                 city = geo.city(ip_address)
             except (GeoIP2Error, GeoIP2Exception):
                 logger.exception(


### PR DESCRIPTION
It's helpful for projects not having the geoIP installed at all to continue using the tracker