### PR TITLE
Update logic to set user instance.

### DIFF
--- a/tracking_analyzer/manager.py
+++ b/tracking_analyzer/manager.py
@@ -1,6 +1,8 @@
+# -*- coding: utf-8 -*-
+
 import logging
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.contrib.gis.geoip2 import GeoIP2, GeoIP2Exception
 from django.db import models
 from django.http import HttpRequest
@@ -34,7 +36,7 @@ class TrackerManager(models.Manager):
             '`content_object` is not a Django model'
 
         user = request.user
-        user = user if isinstance(user, User) else None
+        user = user if isinstance(user, get_user_model()) else None
 
         if request.user_agent.is_mobile:
             device_type = self.model.MOBILE


### PR DESCRIPTION
comparison of the 'request.user' class with 'django.contrib.auth.models.User' class before saving the data to the Tracker model is updated with comparison from the output of get_user_model method of "django.contrib.auth"

Comparing the "request.user" with get_user_model method's output will make sure that this module works with the Django Custom User Models.

In the Tracker model for referencing the user, we are already using settings.AUTH_USER_MODEL which works well with the custom user models. This manager was the only place which was preventing the custom user model used to be counted as non-anonymous users.